### PR TITLE
Pop up "Loading..." screen when re-evaluating cascade parameters

### DIFF
--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -419,9 +419,13 @@ var UnoChoice = UnoChoice || (function($) {
                 e.stopImmediatePropagation();
             } else {
                 console.log('Cascading changes from parameter ' + _self.paramName + '...');
-                //jQuery(".behavior-loading").show();
-                //jQuery(_self.cascadeParameter.getParameterElement).loading(true);
-                _self.cascadeParameter.update();
+                //_self.cascadeParameter.loading(true);
+                jQuery(".behavior-loading").show();
+                // start updating in separate async function so browser will be able to repaint and show 'loading' animation , see JENKINS-34487
+                setTimeout(function () {
+                   _self.cascadeParameter.update(); 
+                   jQuery(".behavior-loading").hide();
+                }, 0);
             }
         });
         cascadeParameter.getReferencedParameters().push(this);


### PR DESCRIPTION
I've found a way to avoid major browser hang when cascade parameter is re-evaluated by a change. 

The idea is to pop-up "Loading" screen, and then start actual update operation by firing a timer. It makes browser re-draw and show the "Loading" screen while the script updates actual parameters. 
(see https://issues.jenkins-ci.org/browse/JENKINS-34487 for motivation behind the change)

The feature may be browser-specific as it affects the redrawing procedure.
I've tested on Chrome only. (Not sure how to set up the test env for a major testing)

Looking forward for your review and suggestions!

PS. It would be nice to have this functionality be turned on\off in the Jenkins settings. Not sure what should I add to setting-related files to make this happen (never developed jenkins plugins before).
