### PR TITLE
AC broken filter for check/radio options [FIXED JENKINS-67982]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 work/
 target/
 test-output/
+.idea/
 .classpath
 .settings/
 .project

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -799,7 +799,7 @@ var UnoChoice = UnoChoice || (function($) {
             var options = _self.originalArray;
             var newOptions = Array();
             for (var i = 0; i < options.length; i++) {
-                if (options[i].tagName === 'INPUT') {
+                if (typeof options[i] !== 'undefined' && options[i].tagName === 'INPUT' ) {
                     if (options[i].getAttribute('alt') && options[i].getAttribute('alt') !== options[i].value) {
                         if (options[i].getAttribute('alt').toLowerCase().match(text)) {
                             newOptions.push(options[i]);
@@ -810,7 +810,7 @@ var UnoChoice = UnoChoice || (function($) {
                         }
                     }
                 } else {
-                    if (options[i].innerHTML.toLowerCase().match(text)) {
+                    if (typeof options[i] !== 'undefined' && options[i].innerHTML.toLowerCase().match(text)) {
                         newOptions.push(options[i]);
                     }
                 }


### PR DESCRIPTION
Previous code failed on undefined elements in options. Every other element was undefined. We now check for these and skip processing if an element is undefined. Filter works for all AC options and parameter values passed to the build are as expected